### PR TITLE
Fix gnome-terminal bug

### DIFF
--- a/dk/views/container_details.py
+++ b/dk/views/container_details.py
@@ -98,7 +98,7 @@ class ContainerDetailsView():
                     description="Opens a new sh shell in the container",
                     highlightable=False,
                     on_enter=RunScriptAction(
-                        "%s -e docker exec -it %s sh" %
+                        "%s -- docker exec -it %s sh" %
                         (default_terminal, container.short_id), [])))
 
             items.append(
@@ -131,7 +131,7 @@ class ContainerDetailsView():
                                     description="Show logs of the container",
                                     highlightable=False,
                                     on_enter=RunScriptAction(
-                                        "%s -e docker logs -f %s" %
+                                        "%s -- docker logs -f %s" %
                                         (default_terminal, container.short_id),
                                         [])))
 


### PR DESCRIPTION
The "open container shell" or "logs" commands have no effect on gnome-terminal. The cause for it is a deprecated gnome-terminal option.

From the gnome-terminal output:
> Option `-e` is deprecated and might be removed in a later version of gnome-terminal.
> Use `--` to terminate the options and put the command line to execute after it.
